### PR TITLE
Avoid using custom secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,5 +17,5 @@ jobs:
         docker build -t docker.pkg.github.com/pavel-the-best/jjs-client/client:latest .
     - name: Upload docker image
       run: |
-        docker login --username pavel-the-best --password ${{ secrets.PKG_REGISTRY_TOKEN }} docker.pkg.github.com
+        docker login --username pavel-the-best --password ${{ secrets.GITHUB_TOKEN }} docker.pkg.github.com
         docker push docker.pkg.github.com/pavel-the-best/jjs-client/client:latest


### PR DESCRIPTION
Now there is no need to use custom
secret for authenticating to Github Package Registry